### PR TITLE
Siteconfigs new version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django==3.1.10
 django-autoslug==1.9.8
 django-extensions==3.1.3
 django-integrations==0.1.1
-django-site-configs==0.1.2
+django-site-configs==0.1.3
 iso4217==1.6.20180829
 pytz==2021.1
 sqlparse==0.4.1

--- a/vendorpromo/__version__.py
+++ b/vendorpromo/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.9"
+VERSION = "0.1.10"

--- a/vendorpromo/processors/__init__.py
+++ b/vendorpromo/processors/__init__.py
@@ -6,4 +6,4 @@ from siteconfigs.models import SiteConfigModel
 
 def get_site_promo_processor(site):
     site_processor = PromoProcessorSiteConfig(site)
-    return import_string(f"vendorpromo.processors.{site_processor.get_key_value()['promo_processor']}")
+    return import_string(f"vendorpromo.processors.{site_processor.get_key_value('promo_processor')}")


### PR DESCRIPTION
Update to new version of siteconfigs to make getting a setting value more convenient. This is not big enough to necessitate its own release and can be bundled into the next set of changes.